### PR TITLE
Fix translation

### DIFF
--- a/src/Hive/Messages/ErrorMessage.tsx
+++ b/src/Hive/Messages/ErrorMessage.tsx
@@ -12,7 +12,7 @@ const ErrorMessage = ({ reason }: Props) => {
       msg = 'bruker ugyldige bokstaver';
       break;
     case 'missing-center':
-      msg = 'mangler obligatorisk brev';
+      msg = 'mangler obligatorisk bokstaven';
       break;
     case 'too-short':
       msg = 'for kort';


### PR DESCRIPTION
Replaces "brev" (as in "letter to be sent") with "bokstaven", definite form of "bokstav" (alphabetic letter).